### PR TITLE
Add DNSai to Online APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ API | Description | Auth | HTTPS | Link | Free / Commercial|
 | Cybergreen | How clean is a network  | `apiKey` | Yes | [Link!](http://stats.cybergreen.net/download/) |?|
 | CyCAT.org | The Cybersecurity Resource Catalogue public API services. | `none` | Yes | [Link!](https://api.cycat.org/) |Free - OpenAPI|
 | defend.network | Daily-updated free JSON feed of CVEs with CVSS, EPSS, CISA KEV status and exploitation state | `none` | Yes | [Link!](https://defend.network/api/) |Free|
+| DNSai | DNS, SPF, DKIM, DMARC, WHOIS and email-security lookups | `none` | Yes | [Link!](https://dnsai.com/api/) |Free/Commercial|
 | Domaintools | Commercial Threat Intel  | `apiKey` | Yes | [Link!](https://www.domaintools.com/products/api-integration/) |Commercial|
 | Dragos WorldView | ICS Threat Intelligence  | `apiKey` | Yes | [Link!](https://portal.dragos.com/api/v1/doc/) |Commercial|
 | DShield | Internet Storm Center API  | `apiKey` | Yes | [Link!](https://www.dshield.org/api/) |Free|


### PR DESCRIPTION
Adds DNSai to the Online API table (alphabetically in the D cluster, between defend.network and Domaintools). DNSai is a free JSON/REST + MCP API for DNS, SPF, DKIM, DMARC, WHOIS and email-security lookups, usable anonymously (no key) with a free tier.

Disclosure: I'm affiliated with DNSai. Happy to adjust the row to match table conventions.